### PR TITLE
[vxlan] Implement VxLAN src port range feature

### DIFF
--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -157,7 +157,7 @@ void SwitchOrch::doCfgSensorsTableTask(Consumer &consumer)
 }
 
 
-sai_status_t SwitchOrch::switchTunnelSetVxlanParams(swss::FieldValueTuple &val)
+sai_status_t SwitchOrch::setSwitchTunnelVxlanParams(swss::FieldValueTuple &val)
 {
     auto attribute = fvField(val);
     auto value = fvValue(val);
@@ -171,13 +171,13 @@ sai_status_t SwitchOrch::switchTunnelSetVxlanParams(swss::FieldValueTuple &val)
         attr.value.s32 = SAI_TUNNEL_VXLAN_UDP_SPORT_MODE_USER_DEFINED;
         status = sai_switch_api->set_switch_tunnel_attribute(switch_tunnel_id, &attr);
 
-        m_vxlanSportUserModeEnabled = true;
-
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to set SAI_TUNNEL_VXLAN_UDP_SPORT_MODE_USER_DEFINED  src port mode rv:%d",  status);
             return status;
         }
+
+        m_vxlanSportUserModeEnabled = true;
     }
 
     attr.id = switch_tunnel_attribute_map.at(attribute);
@@ -231,8 +231,8 @@ void SwitchOrch::doAppSwitchTableTask(Consumer &consumer)
                         break;
                     }
 
-                    auto status = switchTunnelSetVxlanParams(i);
-                    if (status != SAI_STATUS_SUCCESS && handleSaiSetStatus(SAI_API_SWITCH, status) == task_need_retry)
+                    auto status = setSwitchTunnelVxlanParams(i);
+                    if ((status != SAI_STATUS_SUCCESS) && (handleSaiSetStatus(SAI_API_SWITCH, status) == task_need_retry))
                     {
                         retry = true;
                         break;

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -33,6 +33,8 @@ private:
     void doTask(swss::SelectableTimer &timer);
     void doCfgSensorsTableTask(Consumer &consumer);
     void doAppSwitchTableTask(Consumer &consumer);
+    bool switchTunnelSetVxlanParams(swss::FieldValueTuple i);
+    bool switchTunnelResetDefault();
     void initSensorsTable();
     void querySwitchTpidCapability();
 
@@ -40,6 +42,7 @@ private:
     void doTask(swss::NotificationConsumer& consumer);
     swss::DBConnector *m_db;
     swss::Table m_switchTable;
+    sai_object_id_t switch_tunnel_id;
 
     // ASIC temperature sensors
     std::shared_ptr<swss::DBConnector> m_stateDb = nullptr;

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -42,7 +42,6 @@ private:
     void doTask(swss::NotificationConsumer& consumer);
     swss::DBConnector *m_db;
     swss::Table m_switchTable;
-    sai_object_id_t switch_tunnel_id;
 
     // ASIC temperature sensors
     std::shared_ptr<swss::DBConnector> m_stateDb = nullptr;
@@ -55,6 +54,7 @@ private:
     bool m_numTempSensorsInitialized = false;
     bool m_sensorsMaxTempSupported = true;
     bool m_sensorsAvgTempSupported = true;
+    bool m_userSportModeEnabled = false;
 
     // Information contained in the request from
     // external program for orchagent pre-shutdown state check

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -35,7 +35,7 @@ private:
     void doAppSwitchTableTask(Consumer &consumer);
     void initSensorsTable();
     void querySwitchTpidCapability();
-    sai_status_t switchTunnelSetVxlanParams(swss::FieldValueTuple &val);
+    sai_status_t setSwitchTunnelVxlanParams(swss::FieldValueTuple &val);
 
     swss::NotificationConsumer* m_restartCheckNotificationConsumer;
     void doTask(swss::NotificationConsumer& consumer);

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -33,8 +33,7 @@ private:
     void doTask(swss::SelectableTimer &timer);
     void doCfgSensorsTableTask(Consumer &consumer);
     void doAppSwitchTableTask(Consumer &consumer);
-    bool switchTunnelSetVxlanParams(swss::FieldValueTuple i);
-    bool switchTunnelResetDefault();
+    bool switchTunnelSetVxlanParams(swss::FieldValueTuple &val);
     void initSensorsTable();
     void querySwitchTpidCapability();
 
@@ -42,6 +41,7 @@ private:
     void doTask(swss::NotificationConsumer& consumer);
     swss::DBConnector *m_db;
     swss::Table m_switchTable;
+    sai_object_id_t switch_tunnel_id;
 
     // ASIC temperature sensors
     std::shared_ptr<swss::DBConnector> m_stateDb = nullptr;
@@ -54,7 +54,7 @@ private:
     bool m_numTempSensorsInitialized = false;
     bool m_sensorsMaxTempSupported = true;
     bool m_sensorsAvgTempSupported = true;
-    bool m_userSportModeEnabled = false;
+    bool m_vxlanSportUserModeEnabled = false;
 
     // Information contained in the request from
     // external program for orchagent pre-shutdown state check

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -33,9 +33,9 @@ private:
     void doTask(swss::SelectableTimer &timer);
     void doCfgSensorsTableTask(Consumer &consumer);
     void doAppSwitchTableTask(Consumer &consumer);
-    bool switchTunnelSetVxlanParams(swss::FieldValueTuple &val);
     void initSensorsTable();
     void querySwitchTpidCapability();
+    sai_status_t switchTunnelSetVxlanParams(swss::FieldValueTuple &val);
 
     swss::NotificationConsumer* m_restartCheckNotificationConsumer;
     void doTask(swss::NotificationConsumer& consumer);

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -40,14 +40,16 @@ def check_object(db, table, key, expected_attributes):
                                                (value, name, expected_attributes[name])
 
 
-def vxlan_switch_test(dvs, oid, port, mac):
+def vxlan_switch_test(dvs, oid, port, mac, mask, sport):
     app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
     create_entry_pst(
         app_db,
         "SWITCH_TABLE", ':', "switch",
         [
             ("vxlan_port", port),
-            ("vxlan_router_mac", mac)
+            ("vxlan_router_mac", mac),
+            ("vxlan_mask", mask),
+            ("vxlan_sport", sport),
         ],
     )
     time.sleep(2)
@@ -57,6 +59,8 @@ def vxlan_switch_test(dvs, oid, port, mac):
         {
             'SAI_SWITCH_ATTR_VXLAN_DEFAULT_PORT': port,
             'SAI_SWITCH_ATTR_VXLAN_DEFAULT_ROUTER_MAC': mac,
+            'SAI_SWITCH_TUNNEL_ATTR_VXLAN_UDP_SPORT_MASK': mask,
+            'SAI_SWITCH_TUNNEL_ATTR_VXLAN_UDP_SPORT': sport,
         }
     )
 
@@ -67,10 +71,9 @@ class TestSwitch(object):
     '''
     def test_switch_attribute(self, dvs, testlog):
         switch_oid = get_exist_entry(dvs, "ASIC_STATE:SAI_OBJECT_TYPE_SWITCH")
+        vxlan_switch_test(dvs, switch_oid, "12345", "00:01:02:03:04:05", "20", "54321")
 
-        vxlan_switch_test(dvs, switch_oid, "12345", "00:01:02:03:04:05")
-
-        vxlan_switch_test(dvs, switch_oid, "56789", "00:0A:0B:0C:0D:0E")
+        vxlan_switch_test(dvs, switch_oid, "56789", "00:0A:0B:0C:0D:0E", "15", "56789")
 
 
 # Add Dummy always-pass test at end as workaroud


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added interlayer between APP_DB and SAI for VXLAN for src port range feature. 

**Why I did it**
Need to add ability to configure VXLAN src port feature 

**How I verified it**
Use appropriate VS test
```
 sudo pytest --dvsname=vs tests/test_switch.py::TestSwitch::test_switch_attribute -v -s
```

Create json file with params.
Use swssconfig to enable feature and write config params to APP_DB : ```swssconfig /etc/swss/config.d/switch.json``` 

```
switch.json:
[
    {
        "SWITCH_TABLE:switch": {
			"vxlan_sport": "0xFFA0",
			"vxlan_mask": "3"
        },
        "OP": "SET"
    }
]
```

**Details if related**
